### PR TITLE
Use FAISS index in Gradio RAG demo

### DIFF
--- a/gradio_app/faiss_helper.py
+++ b/gradio_app/faiss_helper.py
@@ -1,0 +1,25 @@
+import os
+from typing import Dict, List, Optional
+from langchain.vectorstores import FAISS
+from langchain.embeddings import OpenAIEmbeddings, HuggingFaceEmbeddings
+
+
+def get_embeddings(use_openai: bool = True):
+    """Return embeddings instance using OpenAI or a local model."""
+    if use_openai:
+        return OpenAIEmbeddings()
+    return HuggingFaceEmbeddings(model_name="sentence-transformers/all-MiniLM-L6-v2")
+
+
+def load_or_build_index(docs: Dict[str, str], path: Optional[str] = None, *, use_openai: bool = True) -> FAISS:
+    """Load FAISS index from path or build a new one from docs."""
+    embeddings = get_embeddings(use_openai)
+    if path and os.path.exists(path):
+        return FAISS.load_local(path, embeddings, allow_dangerous_deserialization=True)
+
+    texts = list(docs.values())
+    metadatas = [{"title": t} for t in docs]
+    index = FAISS.from_texts(texts=texts, embedding=embeddings, metadatas=metadatas)
+    if path:
+        index.save_local(path)
+    return index


### PR DESCRIPTION
## Summary
- add helper to build or load a FAISS index
- swap keyword matching for FAISS based retrieval
- support CLI/env flag to load an existing index

## Testing
- `python -m py_compile gradio_app/faiss_helper.py gradio_app/gradio_rag_app.py`

------
https://chatgpt.com/codex/tasks/task_e_68623786ecc48327b6b009f2fd649c88