### PR TITLE
Improve README with notebook summaries and setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,52 @@
-# prompt_engineering_course
-Full course content for Prompt Engineering 
+# Prompt Engineering Course
+
+This repo contains a collection of Jupyter notebooks demonstrating various prompt engineering techniques and tools. Use them as interactive playgrounds or reference examples when building your own LLM workflows.
+
+## Notebook Overview
+
+- **LangGraph_Chatbot.ipynb** – LangGraph chatbot with long‑term memory, agentic behavior, and real‑time streaming.
+- **chatbot_with_memory.ipynb** – Persist conversation history across turns using LangGraph memory.
+- **decoding_parameters_playground.ipynb** – Explore temperature, top‑p, and frequency/presence penalties.
+- **decoding_strategies_playground.ipynb** – Compare deterministic vs. stochastic decoding strategies.
+- **function_calling_demo.ipynb** – Convert user intent to structured arguments and call Python functions.
+- **modular_prompt_library_builder.ipynb** – Build reusable prompt blocks with Jinja2 and save them to JSON.
+- **pal_plan_act_pipeline.ipynb** – Let the model generate Python, execute it, then ask for an explanation.
+- **persona_roleplay_workbench.ipynb** – Create multi‑persona role‑play scenarios with tone and length controls.
+- **prompt_anatomy_template.ipynb** – Template prompts with system/user/assistant roles and placeholders.
+- **prompt_versioning_failure_log.ipynb** – Track prompt iterations and failures for robustness analysis.
+- **prompt_versioning_tracker.ipynb** – Log prompt versions with outcomes and notes; export to CSV or Sheets.
+- **self_consistency_uncertainty.ipynb** – Generate multiple answers, vote for consensus, and capture confidence.
+- **shot_prompt_patterns.ipynb** – Try zero‑shot, one‑shot, and few‑shot prompting techniques.
+- **structured_output_validation.ipynb** – Produce JSON‑only responses, validate them, and retry on errors.
+- **tokenization_playground.ipynb** – Inspect tokenization for different models and context‑window limits.
+
+For quick access to all notebooks, see the optional [index.ipynb](index.ipynb) file.
+
+## Requirements
+
+Most notebooks rely on the OpenAI API and interactive widgets. Install the common packages with:
+
+```bash
+pip install -r requirements.txt
+```
+
+Set your `OPENAI_API_KEY` environment variable so the notebooks can call the API.
+
+## Running Locally
+
+1. Install dependencies as shown above.
+2. Export `OPENAI_API_KEY` in your shell (or use a `.env` file).
+3. Launch Jupyter and open any notebook:
+   ```bash
+   jupyter notebook
+   ```
+
+## Running in Google Colab
+
+Open any notebook via the GitHub URL prefixed with `https://colab.research.google.com/`. For example:
+
+```
+https://colab.research.google.com/github/USERNAME/REPO/blob/main/LangGraph_Chatbot.ipynb
+```
+
+Colab will prompt you for an `OPENAI_API_KEY` the first time a notebook runs.

--- a/index.ipynb
+++ b/index.ipynb
@@ -1,0 +1,47 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Demo Notebooks\n",
+    "\n",
+    "List of demo notebooks in this repo. Open any link in Colab or run locally.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "- [LangGraph_Chatbot.ipynb](LangGraph_Chatbot.ipynb)\n",
+    "- [chatbot_with_memory.ipynb](chatbot_with_memory.ipynb)\n",
+    "- [decoding_parameters_playground.ipynb](decoding_parameters_playground.ipynb)\n",
+    "- [decoding_strategies_playground.ipynb](decoding_strategies_playground.ipynb)\n",
+    "- [function_calling_demo.ipynb](function_calling_demo.ipynb)\n",
+    "- [modular_prompt_library_builder.ipynb](modular_prompt_library_builder.ipynb)\n",
+    "- [pal_plan_act_pipeline.ipynb](pal_plan_act_pipeline.ipynb)\n",
+    "- [persona_roleplay_workbench.ipynb](persona_roleplay_workbench.ipynb)\n",
+    "- [prompt_anatomy_template.ipynb](prompt_anatomy_template.ipynb)\n",
+    "- [prompt_versioning_failure_log.ipynb](prompt_versioning_failure_log.ipynb)\n",
+    "- [prompt_versioning_tracker.ipynb](prompt_versioning_tracker.ipynb)\n",
+    "- [self_consistency_uncertainty.ipynb](self_consistency_uncertainty.ipynb)\n",
+    "- [shot_prompt_patterns.ipynb](shot_prompt_patterns.ipynb)\n",
+    "- [structured_output_validation.ipynb](structured_output_validation.ipynb)\n",
+    "- [tokenization_playground.ipynb](tokenization_playground.ipynb)\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "pygments_lexer": "ipython3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,13 @@
+openai
+ipywidgets
+pandas
+jinja2
+textstat
+gspread
+oauth2client
+tiktoken
+transformers
+gradio
+langgraph
+langchain-openai
+langchain-community


### PR DESCRIPTION
## Summary
- add a README section summarizing every notebook and how to run them
- document dependencies in a `requirements.txt`
- include a simple `index.ipynb` linking to all notebooks

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68625e927ea88327bc8df1cc54d30966