### PR TITLE
Add token counting and prompt block guide

### DIFF
--- a/prompt_blocks.md
+++ b/prompt_blocks.md
@@ -60,7 +60,7 @@ import json
 with open("prompt_blocks.json") as f:
     blocks = json.load(f)
 
-template = Template("""{{ system }}\nUser: {{ user }}""")
+template = Template("{{ system }}\nUser: {{ user }}")
 final_prompt = template.render(**blocks)
 print(final_prompt)
 ```


### PR DESCRIPTION
## Summary
- explain how token counting works with `tiktoken`
- show sample token counts for a few prompts
- demonstrate saving prompts to `prompt_blocks.json`
- demonstrate composing prompts with Jinja2 templates

## Testing
- `pip install tiktoken`
- `python3 - <<'PY'
import tiktoken
samples=["Hello, world!","Explain quantum computing in simple terms.","Summarize the plot of the movie Inception in one sentence."]
enc=tiktoken.encoding_for_model('gpt-3.5-turbo')
for s in samples:
    print(len(enc.encode(s)))
PY`

------
https://chatgpt.com/codex/tasks/task_e_68625dba52b88327ae58640cf69f7f22