### PR TITLE
Add token counting and Jinja2 library examples

### DIFF
--- a/modular_prompt_library_builder.ipynb
+++ b/modular_prompt_library_builder.ipynb
@@ -20,6 +20,79 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "968d2614",
+   "metadata": {},
+   "source": [
+    "## 🔢 Token Counting\n",
+    "`tiktoken` splits text into tokens according to the model's vocabulary. Below we count tokens for a few short prompts."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3b45735c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import tiktoken\n",
+    "enc = tiktoken.encoding_for_model('gpt-4o-mini')\n",
+    "samples = [\"Hello world\", \"Summarize the article below in 3 bullet points\"]\n",
+    "for s in samples:\n",
+    "    print(f'{s!r} -> {len(enc.encode(s))} tokens')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "22c57a97",
+   "metadata": {},
+   "source": [
+    "## 💾 Save Prompt Blocks\n",
+    "Prompt blocks can be stored in a JSON file named `prompt_blocks.json`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "28615d45",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import json\n",
+    "library = {\n",
+    "    'intro': 'You are a helpful assistant.',\n",
+    "    'task': '{{ instruction }}'\n",
+    "}\n",
+    "with open('prompt_blocks.json', 'w') as fp:\n",
+    "    json.dump(library, fp, indent=2)\n",
+    "print('Saved prompt_blocks.json')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "570d78c5",
+   "metadata": {},
+   "source": [
+    "## 🧩 Compose Blocks with Jinja2\n",
+    "Combine multiple blocks into a final prompt using a Jinja2 template."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "889b6c76",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from jinja2 import Template\n",
+    "with open('prompt_blocks.json') as fp:\n",
+    "    library = json.load(fp)\n",
+    "tmpl = Template('{{ library.intro }}\\n\\n{{ library.task }}')\n",
+    "prompt = tmpl.render(library=library, instruction='Say hello')\n",
+    "print(prompt)"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "id": "80761e32",


### PR DESCRIPTION
## Summary
- expand `modular_prompt_library_builder.ipynb` with notes on token counting
- show how to persist prompt blocks in `prompt_blocks.json`
- demonstrate combining blocks using a Jinja2 template

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68625dba52b88327ae58640cf69f7f22