### PR TITLE
Add module 1 introduction

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,9 @@ This repository includes a curated collection of hands-on Jupyter notebooks, eac
 
 > 💡 **Tip:** Each notebook builds on foundational concepts and introduces hands-on tasks. Feel free to modify prompts, adjust parameters, and explore what works best for your use case.
 
+## Course Modules
+- [Module 1: Introduction to Prompt Engineering](docs/module_1_intro.md)
+
 ---
 ## Installation Instructions
 

--- a/docs/module_1_intro.md
+++ b/docs/module_1_intro.md
@@ -1,0 +1,104 @@
+# Module 1: Introduction to Prompt Engineering
+
+Welcome to the first module of the Prompt Engineering Course! This module lays the foundation for everything you will build throughout the rest of the program. By the end, you should feel comfortable explaining what prompt engineering is, why it matters, and how different models interpret your prompts.
+
+## Learning Objectives
+
+By completing this module you will be able to:
+- **Define prompt engineering** and describe its role in modern AI workflows.
+- **Explain why good prompting skills are important** for reliability and controllability.
+- **Identify key terminology** such as *tokens*, *context window*, *system prompt*, and *decoding parameters*.
+- **Recognize the different families of AI models** used for prompting, including proprietary APIs and open-source alternatives.
+- **Run a few hands‑on examples** to see how minor changes in prompts influence the output.
+
+---
+
+## 1. What Is Prompt Engineering?
+
+Prompt engineering is the practice of crafting textual instructions that steer an AI model toward a desired behavior. In the same way that a software engineer writes code to instruct a computer, a prompt engineer writes carefully structured natural language (and sometimes structured data like JSON) so that a language model produces useful responses.
+
+### Key Principles
+1. **Clarity** – Prompts should be explicit about what you want.
+2. **Constraints** – Good prompts include limits on style, length or format.
+3. **Iteration** – Rarely will your first prompt be perfect; tweaking and testing is essential.
+4. **Evaluation** – Use automated metrics and human feedback to measure success.
+
+Prompt engineering sits at the intersection of linguistics, software design, and human‑computer interaction. As models become more capable, well‑crafted prompts allow you to push them further while reducing undesired behavior.
+
+---
+
+## 2. Why Is It Important?
+
+Large language models are trained on massive corpora of text and are surprisingly capable, but they are also sensitive to how instructions are phrased. A small change in wording can mean the difference between a concise answer and a verbose, off‑topic rant. Poorly written prompts lead to wasted API calls, confusing outputs, and even security vulnerabilities.
+
+**Well‑engineered prompts help you:**
+- **Save time and cost** by reducing trial‑and‑error.
+- **Achieve consistent quality** across multiple runs or deployments.
+- **Mitigate risks** such as unwanted content generation or prompt injection.
+- **Unlock advanced workflows** like multi‑agent coordination or retrieval‑augmented generation.
+
+---
+
+## 3. Basic Concepts and Terminology
+
+Below are some of the most common terms you will encounter throughout the course. Feel free to revisit this list as a quick reference.
+
+| Term | Meaning |
+|------|---------|
+| **Token** | The smallest unit of text the model processes (roughly 4 characters). |
+| **Context Window** | The maximum number of tokens the model can consider at once. |
+| **System/User/Assistant** | Roles that structure a conversation prompt for chat‑based models. |
+| **Temperature** | Controls randomness in generation (0 = deterministic, >1 = creative). |
+| **Top‑p / Top‑k** | Sampling techniques that further influence diversity. |
+| **Function Calling** | Mechanism for requesting structured JSON output or API calls. |
+| **Prompt Template** | Reusable prompt with placeholders for dynamic values. |
+
+Other important ideas include **few‑shot prompting**, **prompt chaining**, and **self‑consistency**. You will explore these in later modules.
+
+---
+
+## 4. Overview of Different AI Models
+
+While this course focuses on text‑based LLMs, it helps to know the wider AI landscape. Models generally fall into a few categories:
+1. **Proprietary APIs** – Examples include OpenAI's GPT‑4 and Anthropic's Claude. They offer excellent performance but you rely on remote APIs.
+2. **Open‑source LLMs** – Projects like Llama 3, Mistral, and Mixtral can run locally or on your own servers for greater control.
+3. **Instruction‑tuned Models** – Many open models are fine‑tuned on human instructions so they respond well to prompts (e.g., Zephyr, OpenHermes).
+4. **Multimodal Models** – Newer systems accept text *and* images or other data modalities, broadening the scope of what prompts can do.
+
+Each model family may interpret prompts slightly differently. Throughout the course you will compare responses from a variety of models and learn where each one excels.
+
+---
+
+## 5. First Hands‑On Examples
+
+Nothing beats experimenting for yourself. Below are two simple exercises to try in the OpenAI Playground or your preferred notebook environment.
+
+### Example 1: Controlled Summary
+1. **Prompt:**
+   ```
+   Summarize the following news article in exactly three sentences, using a
+   neutral, professional tone:
+   {{article_text}}
+   ```
+2. **Experiment:**
+   - Try the same prompt with different temperature values.
+   - Notice how a higher temperature increases variability in the wording.
+
+### Example 2: Persona Swap
+1. **Prompt:**
+   ```
+   You are a cheerful tour guide. Describe the Eiffel Tower in 40 words or
+   fewer.
+   ```
+2. **Experiment:**
+   - Rewrite the persona (“grumpy historian,” “excited teenager,” etc.) and observe how the tone shifts while the factual content remains.
+
+These small exercises demonstrate how precise wording and constraints shape the model’s behavior. As you progress, you’ll chain multiple prompts, incorporate structured outputs, and evaluate results programmatically.
+
+---
+
+## Next Steps
+
+After completing this module you are ready to dive deeper into prompt patterns, sampling strategies, and building reusable templates. Continue to **Module 2** for an exploration of foundational prompt patterns and persona workflows.
+
+Happy prompting!

--- a/docs/module_1_intro.md
+++ b/docs/module_1_intro.md
@@ -5,7 +5,8 @@ Welcome to the first module of the Prompt Engineering Course! This module lays t
 ## Learning Objectives
 
 By completing this module you will be able to:
-- **Define prompt engineering** and describe its role in modern AI workflows.
+- **Define prompt engineering** as the practice of crafting textual instructions to guide AI behavior.
+- **Describe the role of prompt engineering** in modern AI workflows, including its impact on model performance and reliability.
 - **Explain why good prompting skills are important** for reliability and controllability.
 - **Identify key terminology** such as *tokens*, *context window*, *system prompt*, and *decoding parameters*.
 - **Recognize the different families of AI models** used for prompting, including proprietary APIs and open-source alternatives.


### PR DESCRIPTION
## Summary
- create Module 1 primer covering prompt engineering basics
- reference new module in README

## Testing
- `python test_fallback_behavior.py` *(fails: No module named 'langchain_community')*

------
https://chatgpt.com/codex/tasks/task_e_686ebcb2eb708327a3a0c2eb6a0c1ebe